### PR TITLE
Fix test makefile on non-GNU find

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,9 +21,9 @@ IMCONVERT ?= convert
 
 BUILD_PATH := build
 
-SRC := $(filter-out ./common/%.s,$(shell find -type f -name '*.s'))
+SRC := $(filter-out ./common/%.s,$(shell find . -type f -name '*.s'))
 
-LATEX_SRC := $(shell find -type f -name '*.tex')
+LATEX_SRC := $(shell find . -type f -name '*.tex')
 
 all: $(addprefix $(BUILD_PATH)/, $(patsubst %.s,%.gb, $(SRC)))
 


### PR DESCRIPTION
`find` requires a path on non-GNU versions, which defaults to `.` on GNU versions. This PR makes it explicit.