### PR TITLE
Update BGB accuracy chart

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -172,7 +172,7 @@ On Windows, also download an SDL2 package containing SDL2.dll, and put it to
 Versions used:
 
 * mooneye-gb (master)
-* BGB 1.5.6
+* BGB 1.5.7
 * Gambatte 2015-03-23 (f9fb003)
 * Higan v098 (in Game Boy mode, except for SGB/SGB2-specific test ROMs)
 * MESS 0.179
@@ -219,16 +219,16 @@ Notes:
 | add sp e timing         | :+1:       | :x:  | :+1:     | :+1:   | :+1: |
 | boot div dmg0           | :x:        | :o:  |          |        | :+1: |
 | boot div dmgABCmgb      | :x:        | :+1: | :+1:     | :x:    | :+1: |
-| boot div S              | :x:        | :o:  |          | :+1:   | :+1: |
-| boot div2 S             | :x:        | :o:  |          | :+1:   | :+1: |
+| boot div S              | :x:        | :+1: |          | :+1:   | :+1: |
+| boot div2 S             | :x:        | :+1: |          | :+1:   | :+1: |
 | boot hwio dmg0          | :x:        | :o:  |          |        | :+1: |
 | boot hwio dmgABCmgb     | :x:        | :+1: | :+1:     | :x:    | :+1: |
-| boot hwio S             | :+1:       | :o:  |          | :+1:   | :x:  |
+| boot hwio S             | :+1:       | :+1: |          | :+1:   | :x:  |
 | boot regs dmg0          | :+1:       | :o:  |          |        | :+1: |
 | boot regs dmgABC        | :+1:       | :+1: | :+1:     | :+1:   | :+1: |
-| boot regs mgb           | :+1:       | :o:  |          |        | :+1: |
-| boot regs sgb           | :+1:       | :o:  |          | :+1:   | :+1: |
-| boot regs sgb2          | :+1:       | :o:  |          | :x:    | :+1: |
+| boot regs mgb           | :+1:       | :+1: |          |        | :+1: |
+| boot regs sgb           | :+1:       | :+1: |          | :+1:   | :+1: |
+| boot regs sgb2          | :+1:       | :+1: |          | :x:    | :+1: |
 | call timing             | :+1:       | :x:  | :+1:     | :+1:   | :+1: |
 | call timing2            | :+1:       | :x:  | :+1:     | :+1:   | :+1: |
 | call cc_timing          | :+1:       | :x:  | :+1:     | :+1:   | :+1: |
@@ -260,9 +260,8 @@ Notes:
 
 Notes:
 
-* BGB passes most boot tests only if you explicitly enable boot ROMs and give
-  it the right one. This makes sense for some device versions (e.g. DMG0)
-  because they are not selectable, but SGB should work without boot ROMs out of
+* BGB passes DMG0 boot tests only if you explicitly enable boot ROMs and give
+  it the right one. Other, selectable device versions work without boot ROMs out of
   the box.
 
 #### Bits (unusable bits in memory and registers)
@@ -271,7 +270,7 @@ Notes:
 | -------------- | ---------- | ---- | -------- | ------| ---- |
 | mem oam        | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
 | reg f          | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
-| unused_hwio GS | :+1:       | :x:  | :+1:     | :x:   | :+1: |
+| unused_hwio GS | :+1:       | :+1: | :+1:     | :x:   | :+1: |
 
 #### Instructions
 
@@ -297,42 +296,42 @@ Notes:
 
 | Test                        | mooneye-gb | BGB  | Gambatte | Higan | MESS |
 | --------------------------- | ---------- | ---- | -------- | ------| ---- |
-| hblank ly scx timing GS     | :+1:       | :x:  | :x:      | :x:   | :+1: |
+| hblank ly scx timing GS     | :+1:       | :+1: | :x:      | :x:   | :+1: |
 | intr 1 2 timing GS          | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
 | intr 2 0 timing             | :+1:       | :+1: | :x:      | :+1:  | :+1: |
 | intr 2 mode0 timing         | :+1:       | :+1: | :x:      | :x:   | :+1: |
 | intr 2 mode3 timing         | :+1:       | :+1: | :x:      | :x:   | :+1: |
 | intr 2 oam ok timing        | :+1:       | :+1: | :x:      | :x:   | :+1: |
-| intr 2 mode0 timing sprites | :x:        | :x:  | :x:      | :x:   | :+1: |
+| intr 2 mode0 timing sprites | :x:        | :+1: | :x:      | :x:   | :+1: |
 | lcdon timing dmgABCmgbS     | :x:        | :+1: | :x:      | :x:   | :x:  |
-| lcdon write timing GS       | :x:        | :x:  | :x:      | :x:   | :x:  |
-| stat irq blocking           | :x:        | :x:  | :+1:     | :x:   | :+1: |
-| stat lyc onoff              | :x:        | :x:  | :x:      | :x:   | :x:  |
+| lcdon write timing GS       | :x:        | :+1: | :x:      | :x:   | :x:  |
+| stat irq blocking           | :x:        | :+1: | :+1:     | :x:   | :+1: |
+| stat lyc onoff              | :x:        | :+1: | :x:      | :x:   | :x:  |
 | vblank stat intr GS         | :+1:       | :+1: | :x:      | :+1:  | :+1: |
 
 #### Serial
 
 | Test                        | mooneye-gb | BGB  | Gambatte | Higan | MESS |
 | --------------------------- | ---------- | ---- | -------- | ------| ---- |
-| boot sclk align dmgABCmgb   | :x:        | :x:  | :+1:     | :x:   | :x:  |
+| boot sclk align dmgABCmgb   | :x:        | :+1: | :+1:     | :x:   | :x:  |
 
 #### Timer
 
 | Test                 | mooneye-gb | BGB  | Gambatte | Higan  | MESS |
 | -------------------- | ---------- | ---- | -------- | ------ | ---- |
 | div write            | :+1:       | :+1: | :x:      | :+1:   | :+1: |
-| rapid toggle         | :+1:       | :x:  | :x:      | :x:    | :+1: |
-| tim00 div trigger    | :+1:       | :x:  | :+1:     | :x:    | :+1: |
+| rapid toggle         | :+1:       | :+1: | :x:      | :x:    | :+1: |
+| tim00 div trigger    | :+1:       | :+1: | :+1:     | :x:    | :+1: |
 | tim00                | :+1:       | :+1: | :x:      | :+1:   | :+1: |
 | tim01 div trigger    | :+1:       | :+1: | :x:      | :x:    | :+1: |
 | tim01                | :+1:       | :+1: | :+1:     | :+1:   | :+1: |
 | tim10 div trigger    | :+1:       | :+1: | :x:      | :x:    | :+1: |
 | tim10                | :+1:       | :+1: | :x:      | :+1:   | :+1: |
-| tim11 div trigger    | :+1:       | :x:  | :x:      | :x:    | :+1: |
+| tim11 div trigger    | :+1:       | :+1: | :x:      | :x:    | :+1: |
 | tim11                | :+1:       | :+1: | :x:      | :+1:   | :+1: |
-| tima reload          | :+1:       | :x:  | :x:      | :x:    | :+1: |
-| tima write reloading | :+1:       | :x:  | :x:      | :x:    | :+1: |
-| tma write reloading  | :+1:       | :x:  | :x:      | :x:    | :+1: |
+| tima reload          | :+1:       | :+1: | :x:      | :x:    | :+1: |
+| tima write reloading | :+1:       | :+1: | :x:      | :x:    | :+1: |
+| tma write reloading  | :+1:       | :+1: | :x:      | :x:    | :+1: |
 
 ### Mooneye GB emulator-only tests
 
@@ -341,15 +340,15 @@ Notes:
 | Test              | mooneye-gb | BGB  | Gambatte | Higan | MESS |
 | ----------------- | ---------- | ---- | -------- | ----- | ---- |
 | bits ram en       | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
-| rom 512Kb         | :+1:       | :x:  | :+1:     | :+1:  | :+1: |
-| rom 1Mb           | :+1:       | :x:  | :+1:     | :+1:  | :+1: |
-| rom 2Mb           | :+1:       | :x:  | :+1:     | :+1:  | :+1: |
+| rom 512Kb         | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
+| rom 1Mb           | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
+| rom 2Mb           | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
 | rom 4Mb           | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
-| rom 8Mb           | :+1:       | :x:  | :x:      | :x:   | :+1: |
-| rom 16Mb          | :+1:       | :x:  | :x:      | :x:   | :+1: |
+| rom 8Mb           | :+1:       | :+1: | :x:      | :x:   | :+1: |
+| rom 16Mb          | :+1:       | :+1: | :x:      | :x:   | :+1: |
 | ram 64Kb          | :+1:       | :+1: | :+1:     | :+1:  | :+1: |
 | ram 256Kb         | :+1:       | :+1: | :x:      | :x:   | :+1: |
-| multicart rom 8Mb | :+1:       |      |          | :x:   | :+1: |
+| multicart rom 8Mb | :+1:       | :+1: |          | :x:   | :+1: |
 
 Notes:
 
@@ -371,14 +370,14 @@ Notes:
 | boot div cgb0     |            |      |          |       |      |
 | boot div cgbABCDE |            | :+1: |          |       | :+1: |
 | boot hwio C       |            | :+1: |          |       | :x:  |
-| boot regs A       |            | :x:  |          |       |      |
+| boot regs A       |            | :+1: |          |       |      |
 | boot regs cgb     |            | :+1: |          |       | :+1: |
 
 #### Bits
 
 | Test          | mooneye-gb | BGB  | Gambatte | Higan | MESS |
 | ------------- | ---------- | ---- | -------- | ----- | ---- |
-| unused hwio C |            | :x:  |          |       | :x:  |
+| unused hwio C |            | :+1: |          |       | :x:  |
 
 #### PPU
 


### PR DESCRIPTION
Results according to https://github.com/ISSOtm/bgb-mooneye-tester/releases/tag/1.5.7