### PR TITLE
Fix warning on release build with `cargo build --release`

### DIFF
--- a/core/src/hardware/ppu.rs
+++ b/core/src/hardware/ppu.rs
@@ -30,7 +30,7 @@ const ACCESS_VRAM_CYCLES: isize = 43;
 const HBLANK_CYCLES: isize = 50;
 const VBLANK_LINE_CYCLES: isize = 114;
 const UNDEFINED_READ: u8 = 0xff;
-const STAT_UNUSED_MASK: u8 = (1 << 7);
+const STAT_UNUSED_MASK: u8 = 1 << 7;
 
 #[derive(Clone)]
 pub struct Ppu {


### PR DESCRIPTION
This commit fixes the following warning emit by rustc v1.57:

```
> cargo build --release

warning: unnecessary parentheses around assigned value
  --> core/src/hardware/ppu.rs:33:30
   |
33 | const STAT_UNUSED_MASK: u8 = (1 << 7);
   |                              ^      ^
   |
   = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
   |
33 - const STAT_UNUSED_MASK: u8 = (1 << 7);
33 + const STAT_UNUSED_MASK: u8 = 1 << 7;
   |

warning: `mooneye-gb-core` (lib) generated 1 warning
```